### PR TITLE
128x128 and 320x320 framesizes added to support ESP32 v.3.1.3 for Arduino

### DIFF
--- a/v60/ESP32-CAM-Video-Recorder-junior-60x.4.7/ESP32-CAM-Video-Recorder-junior-60x.4.7.ino
+++ b/v60/ESP32-CAM-Video-Recorder-junior-60x.4.7/ESP32-CAM-Video-Recorder-junior-60x.4.7.ino
@@ -306,10 +306,12 @@ struct frameSizeStruct {
 static const frameSizeStruct frameSizeData[] = {
   {{0x60, 0x00}, {0x60, 0x00}}, // FRAMESIZE_96X96,    // 96x96
   {{0xA0, 0x00}, {0x78, 0x00}}, // FRAMESIZE_QQVGA,    // 160x120
+  {{0x80, 0x00}, {0x80, 0x00}}, // FRAMESIZE_128X128,  // 128x128
   {{0xB0, 0x00}, {0x90, 0x00}}, // FRAMESIZE_QCIF,     // 176x144
   {{0xF0, 0x00}, {0xB0, 0x00}}, // FRAMESIZE_HQVGA,    // 240x176
   {{0xF0, 0x00}, {0xF0, 0x00}}, // FRAMESIZE_240X240,  // 240x240
-  {{0x40, 0x01}, {0xF0, 0x00}}, // FRAMESIZE_QVGA,     // 320x240   framessize
+  {{0x40, 0x01}, {0xF0, 0x00}}, // FRAMESIZE_QVGA,     // 320x240
+  {{0x40, 0x01}, {0x40, 0x01}}, // FRAMESIZE_320X320,  // 320x320   framessize
   {{0x90, 0x01}, {0x28, 0x01}}, // FRAMESIZE_CIF,      // 400x296       bytes per buffer required in psram - quality must be higher number (lower quality) than config quality
   {{0xE0, 0x01}, {0x40, 0x01}}, // FRAMESIZE_HVGA,     // 480x320       low qual  med qual  high quality
   {{0x80, 0x02}, {0xE0, 0x01}}, // FRAMESIZE_VGA,      // 640x480   8   11+   ##  6-10  ##  0-5         indoor(56,COUNT=3)  (56,COUNT=2)          (56,count=1)


### PR DESCRIPTION
It actually took me a lot of hours to trace this bug down to the `framesize_t` enum change in the new version of the esp32-camera library when I first saw a strangely interlaced and stretched video instead of a usual 640x480 frame.
![mpv-shot0002](https://github.com/user-attachments/assets/f489b68b-e0d0-44cd-b6f1-f0c427128db3)

I hope this small fix saves someone else's time.

Please see [this header ](https://github.com/espressif/esp32-camera/blob/master/driver/include/sensor.h) for reference:
